### PR TITLE
fix load local snapshot

### DIFF
--- a/src/Motan/Cluster/LoadBalance.php
+++ b/src/Motan/Cluster/LoadBalance.php
@@ -64,7 +64,7 @@ abstract class  LoadBalance
         if (!$get_nodes) {
             throw new \Exception('fetch backup nodes err : ' . json_last_error());
         }
-        if (key_exists($get_nodes, 'working')) {
+        if (key_exists('working', $get_nodes)) {
             $working_nodes = $get_nodes['working'];
             foreach ($working_nodes as $info) {
                 $nodes[] = $info['host'];


### PR DESCRIPTION
### fix
load local snapshot
```
#0 [internal function]: Laravel\Lumen\Application->Laravel\Lumen\Concerns\{closure}(2, 'key_exists() ex...', '/home/work/oyst...', 72, Array)
#1 /home/work/oyster/vendor/motan/motan-php/src/Motan/Cluster/LoadBalance.php(72): key_exists(Array, 'working')
#2 /home/work/oyster/vendor/motan/motan-php/src/Motan/Endpointer.php(90): Motan\Cluster\LoadBalance->getNode()
#3 /home/work/oyster/vendor/motan/motan-php/src/Motan/Endpointer.php(128): Motan\Endpointer->_buildConnection()
#4 /home/work/oyster/vendor/motan/motan-php/src/Motan/Endpointer.php(101): Motan\Endpointer->_doSend(Object(Motan\Request))
#5 /home/work/oyster/vendor/motan/motan-php/src/Motan/Cluster/Ha/Failfast.php(39): Motan\Endpointer->call(Object(Motan\Request))
#6 /home/work/oyster/vendor/motan/motan-php/src/Motan/Cluster.php(127): Motan\Cluster\Ha\Failfast->call(Object(Motan\Cluster\LoadBalance\Random), Object(Motan\Request))
#7 /home/work/oyster/vendor/motan/motan-php/src/Motan/Client.php(141): Motan\Cluster->call(Object(Motan\Request))
```