### PR TITLE
add support for each Request can sets it's serialization type of MClient.

### DIFF
--- a/src/Motan/Client.php
+++ b/src/Motan/Client.php
@@ -146,17 +146,27 @@ class Client
         return $this->_endpoint->call($request)->getRs();
     }
 
-    public function multiCall(array $url_objs) {
+    /**
+     * multiCall calls a method on multiple backend.
+     * @param array $url_objs array of backend URL object.
+     * @param string $method  RPC method name.
+     * @param mixed ...$args  arguments will pass to method.
+     * @return array arary of called result, index 0 is the first response of $url_objs.
+     * @throws \Exception, you should try to catch it.
+     */
+    public function multiCall(array $url_objs,string $method, ...$args) {
         if (empty($url_objs)) {
             return [];
         }
+
         $request_objs = [];
         foreach ($url_objs as $url_obj) {
             $request = new \Motan\Request($url_obj->getService(),
-            $url_obj->getMethod(), ...[$url_obj->getParams()]);
+            $method, ...$args);
             $request->addHeaders($url_obj->getHeaders());
             $request->setGroup($url_obj->getGroup());
             $request_objs[] = $request;
+
         }
         return $this->_endpoint->multiCall($request_objs);
     }

--- a/src/Motan/Endpointer.php
+++ b/src/Motan/Endpointer.php
@@ -18,14 +18,15 @@
 namespace Motan;
 
 use Motan\Transport\Connection;
+use Motan\Utils;
 
 /**
  * Motan Endpointer for PHP 5.6+
- * 
+ *
  * <pre>
  * Motan Endpointer
  * </pre>
- * 
+ *
  * @author idevz <zhoujing00k@gmail.com>
  * @version V1.0 [created at: 2016-08-15]
  */
@@ -93,7 +94,7 @@ abstract class  Endpointer
         try {
             $nodes = $this->_loadbalance->getNode();
         } catch (\Exception $e) {
-            /* when mesh down, and we couldn't find a snapshot to direct connect to server, 
+            /* when mesh down, and we couldn't find a snapshot to direct connect to server,
             we will try http backup call.*/
             $this->_back_to_httpcall = TRUE;
             return FALSE;
@@ -141,7 +142,7 @@ abstract class  Endpointer
         $mt_str = implode("\n", $mt);
         $file = $request->getRequestArgs()[0]['file_path'];
         $file_size = \filesize($file);
-        
+
         $buffer = $buffer . pack('N', strlen($mt_str)) . $mt_str . pack('N', $file_size + 5) . pack('C', Constants::DTYPE_STRING) . pack('N', $file_size);
 
         $length = strlen($buffer);
@@ -279,6 +280,14 @@ abstract class  Endpointer
 
     protected function _doSend(\Motan\Request $request)
     {
+        // aquires seialization type from request itself.
+        // notice: $request_seria is a string typed flag.
+        $request_seria=$request->getSerialization();
+        // create seialization object from $request_seria.
+        $serialization=empty($request_seria)?$this->_url_obj->getSerialization():$request_seria;
+        // if create fail, using $this->_serializer as default serializer.
+        $serializer=empty($request_seria)?$this->_serializer:$request->getSerializer();
+
         if ($this->_url_obj->getUrlType() == Constants::REQ_URL_TYPE_RESTY
             || FALSE !== strpos($request->getMethod(), '/')) {
             $request = $request->buildHTTPParams();
@@ -298,7 +307,7 @@ abstract class  Endpointer
         if( !$this->_connection) {
             throw new \Exception("Connection has gone away!");
         }
-        $req_body = $this->_serializer->serializeMulti(...$request->getRequestArgs());
+        $req_body = $serializer->serializeMulti(...$request->getRequestArgs());
 
         // @TODO check GRPC using \Motan\Request
         // if (Constants::PROTOCOL_GRPC === $url_obj->getProtocol()) {
@@ -316,11 +325,11 @@ abstract class  Endpointer
         $metadata['M_g'] = $group;
         $metadata['M_pp'] = $request->getProtocol();
         $metadata['requestIdFromClient'] = $request_id;
-        $metadata['SERIALIZATION'] = $this->_url_obj->getSerialization();
+        $metadata['SERIALIZATION'] = $serialization;
         $http_method = $this->_url_obj->getHttpMethod();
         !empty($http_method) && $metadata['HTTP_Method'] = $http_method;
         $buf = Protocol\Motan::encode($request_id, $req_body, $metadata);
-        
+
         $this->_connection_obj->write($buf);
     }
 
@@ -331,8 +340,16 @@ abstract class  Endpointer
         if ($resp_msg->getHeader()->isGzip()) {
             $resp_body = zlib_decode($resp_body);
         }
+        // aquires seialization type from response header.
+        $resp_seria=$resp_msg->getHeader()->getSerialize();
+        // create seialization object from $resp_seria.
+        // notice: $resp_seria is a int typed flag.
+        $serializer=Utils::getSerializer($resp_seria);
+        // if create fail, using $this->_serializer as default serializer.
+        empty($serializer)&&$serializer=$this->_serializer;
+
         $res = $exception = NULL;
-        $res = $this->_serializer->deserialize($resp_obj, $resp_body);
+        $res = $serializer->deserialize($resp_obj, $resp_body);
         // @TODO Check resp_taged for grpc
         $resp_meta = $resp_msg->getMetadata();
         if (isset($resp_meta['M_e'])) {
@@ -340,7 +357,7 @@ abstract class  Endpointer
         }
         return new \Motan\Response($res, $exception, $resp_msg);
     }
-    
+
     public function multiCall(array $request_objs)
     {
         $result = [];

--- a/src/Motan/Endpointer.php
+++ b/src/Motan/Endpointer.php
@@ -19,6 +19,7 @@ namespace Motan;
 
 use Motan\Transport\Connection;
 use Motan\Utils;
+use const Motan\Protocol\SERIALIZE_SIMPLE;
 
 /**
  * Motan Endpointer for PHP 5.6+
@@ -224,7 +225,7 @@ abstract class  Endpointer
             $exception = new \Exception("back to httpcalling error, url is ${url}");
         }
         $request_id = $request->getRequestId();
-        $raw_header = \Motan\Protocol\Motan::buildResponseHeader($request_id, $status_code);
+        $raw_header = \Motan\Protocol\Motan::buildResponseHeader($request_id,SERIALIZE_SIMPLE, $status_code);
         $metadata['M_p'] = $request->getService();
         $metadata['M_m'] = $request->getMethod();
         $metadata['M_g'] = $request->getGroup();
@@ -329,7 +330,6 @@ abstract class  Endpointer
         $http_method = $this->_url_obj->getHttpMethod();
         !empty($http_method) && $metadata['HTTP_Method'] = $http_method;
         $buf = Protocol\Motan::encode($request_id, $req_body, $metadata);
-
         $this->_connection_obj->write($buf);
     }
 

--- a/src/Motan/Protocol/Header.php
+++ b/src/Motan/Protocol/Header.php
@@ -37,6 +37,13 @@ class Header
     private $_serialize;
     private $_request_id;
 
+    /**
+     * Header constructor.
+     * @param $msg_type
+     * @param $version_status
+     * @param $serialize $serialize is raw number in protocol header
+     * @param $request_id
+     */
     public function __construct($msg_type, $version_status, $serialize, $request_id)
     {
         $this->_magic = MAGIC;

--- a/src/Motan/Protocol/Motan.php
+++ b/src/Motan/Protocol/Motan.php
@@ -52,6 +52,14 @@ const BODY_SIZE_BYTE = 4;
  */
 class Motan
 {
+    /**
+     * @param $msg_type
+     * @param $proxy
+     * @param $serialize  $serialize is hunman readable number
+     * @param $request_id
+     * @param $msg_status
+     * @return Header
+     */
     private static function buildHeader($msg_type, $proxy, $serialize, $request_id, $msg_status)
     {
         $m_type = 0x00;
@@ -65,7 +73,7 @@ class Motan
         }
 
         $status = 0x08 | ($msg_status & 0x07);
-        $serial = 0x00 | $serialize;
+        $serial = 0x00 | ($serialize<<3 & 0x1f);
         return new Header($m_type, $status, $serial, $request_id);
     }
 
@@ -74,9 +82,17 @@ class Motan
         return self::buildHeader(MSG_TYPE_REQUEST, FALSE, SERIALIZE_SIMPLE, $request_id, MSG_STATUS_NORMAL);
     }
 
+    /**
+     * @param $request_id
+     * @param $serialize $serialize is raw number in protocol header
+     * @param $msg_status
+     * @return Header
+     */
     public static function buildResponseHeader($request_id, $serialize,$msg_status)
     {
-        return self::buildHeader(MSG_TYPE_RESPONSE, FALSE, $serialize, $request_id, $msg_status);
+        $status = 0x08 | ($msg_status & 0x07);
+        return new Header(MSG_TYPE_RESPONSE, $status, $serialize, $request_id);
+        //return self::buildHeader(MSG_TYPE_RESPONSE, FALSE, $serialize, $request_id, $msg_status);
     }
 
     public static function encode($request_id, $req_obj, $metadata)

--- a/src/Motan/Protocol/Motan.php
+++ b/src/Motan/Protocol/Motan.php
@@ -65,7 +65,7 @@ class Motan
         }
 
         $status = 0x08 | ($msg_status & 0x07);
-        $serial = 0x00 | ($serialize << 3);
+        $serial = 0x00 | $serialize;
         return new Header($m_type, $status, $serial, $request_id);
     }
 
@@ -74,9 +74,9 @@ class Motan
         return self::buildHeader(MSG_TYPE_REQUEST, FALSE, SERIALIZE_SIMPLE, $request_id, MSG_STATUS_NORMAL);
     }
 
-    public static function buildResponseHeader($request_id, $msg_status)
+    public static function buildResponseHeader($request_id, $serialize,$msg_status)
     {
-        return self::buildHeader(MSG_TYPE_RESPONSE, FALSE, SERIALIZE_SIMPLE, $request_id, $msg_status);
+        return self::buildHeader(MSG_TYPE_RESPONSE, FALSE, $serialize, $request_id, $msg_status);
     }
 
     public static function encode($request_id, $req_obj, $metadata)
@@ -115,11 +115,11 @@ class Motan
         }
         $header = unpack("nmagic/CmessageType/Cversion_status/Cserialize/Nrequest_id_upper/Nrequest_id_lower", $header_buffer);
         $header['request_id'] = Utils::bigInt2float($header['request_id_upper'], $header['request_id_lower']);
-
-        $header_obj = self::buildResponseHeader($header['request_id'], $header['version_status']);
+        $header_obj = self::buildResponseHeader($header['request_id'], $header['serialize'],$header['version_status']);
         if (($header['messageType'] & 0x08) == 0x08) {
             $header_obj->setGzip(TRUE);
         }
+
         $metadata_size_buffer = fread($connection, META_SIZE_BYTE);
         if (FALSE === $metadata_size_buffer) {
             $stream_meta = stream_get_meta_data($connection);

--- a/src/Motan/Request.php
+++ b/src/Motan/Request.php
@@ -22,15 +22,16 @@ use Motan\Constants;
 
 /**
  * Motan  Request for PHP 5.6+
- * 
+ *
  * <pre>
- * Motan Request 
+ * Motan Request
  * </pre>
- * 
+ *
  * @author idevz <zhoujing00k@gmail.com>
  * @version V1.0 [created at: 2019-01-06]
  */
-class Request{
+class Request
+{
     private $_protocol;
     private $_group;
     private $_service;
@@ -38,7 +39,9 @@ class Request{
     private $_request_args;
     private $_request_id;
     private $_request_headers = [];
-   
+    private $_serialization;
+    private $_serializer;
+
     public function __construct($service, $method, ...$request_args)
     {
         if (empty($service) || empty($method)) {
@@ -56,7 +59,7 @@ class Request{
                 $this->_request_args[0][$key] = $value;
             }
         }
-        $this->_request_id = Utils::genRequestId(NULL); 
+        $this->_request_id = Utils::genRequestId(NULL);
     }
 
     public function setProtocol($protocol)
@@ -147,5 +150,40 @@ class Request{
     public function getGroup()
     {
         return $this->_group;
+    }
+
+    /**
+     * setSerialization sets serialization of the request
+     * @param $serialization, value is string typed.such as: simple, breeze
+     */
+    public function setSerialization($serialization)
+    {
+        $this->_serialization = $serialization;
+    }
+
+    /**
+     * setSerialization acquires serialization type of the request.
+     * @return string value is string typed. such as: simple, breeze
+     */
+    public function getSerialization()
+    {
+        return $this->_serialization;
+    }
+
+    /**
+     * getSerializer acquires serialization object of this request,
+     * if serialization type not supported,null will be returned.
+     * @return Serialize\Breeze|Serialize\GrpcJson|Serialize\Motan|Serialize\PB|null
+     */
+    public function getSerializer()
+    {
+        if (is_object($this->_serializer)) {
+            return $this->_serializer;
+        }
+        if (empty($this->getSerialization())) {
+            return null;
+        }
+        $this->_serializer = Utils::getSerializer($this->getSerialization());
+        return $this->_serializer;
     }
 }

--- a/src/Motan/Utils.php
+++ b/src/Motan/Utils.php
@@ -95,6 +95,24 @@ class Utils
 
     public static function getSerializer($type)
     {
+        // support for numeric type, change it to string flag
+        if(is_numeric($type)){
+            switch ($type) {
+                case 6:
+                    $type=Constants::SERIALIZATION_SIMPLE;
+                    break;
+                case 8:
+                    $type=Constants::SERIALIZATION_BREEZE;
+                    break;
+                case 1:// grpcPB
+                    $type=Constants::SERIALIZATION_PB;
+                    break;
+                case 7:
+                    $type=Constants::SERIALIZATION_GRPC_JSON;
+                    break;
+            }
+        }
+
         $serializer = null;
         switch ($type) {
             case Constants::SERIALIZATION_SIMPLE:


### PR DESCRIPTION
Example of `MClient->doMultiCall()`:
```php
$app_name = 'phpt-test-MClient';
$group = "bj";
$service = "com.mycompany.motan.DemoServer";
$mcx = new \Motan\MClient($app_name);
$req1 = new \Motan\Request($service, 'Hello', "motan-php-client-req1");
$req2 = new \Motan\Request($service, 'Hello', "motan-php-client-req2");
$req3 = new \Motan\Request($service, 'Hello', "motan-php-client-req3");
$req1->setGroup($group);
$req2->setGroup($group);
$req3->setGroup($group);
$req1->setSerialization("breeze");
$req2->setSerialization("simple");
$req3->setSerialization("breeze");

$multi_res = $mcx->doMultiCall([
    $req1,
    $req2,
    $req3
]);

foreach ([
             $req1,
             $req2,
             $req3,
         ] as $k => $req) {
    $e = $multi_res->getException($req);
    if (!empty($e)) {
        var_dump("req" . ($k + 1) . " error " . $e);
    } else {
        var_dump($multi_res->getRs($req));
    }
}
```

Example of `Client->multiCal()`:
```php
$url_str = 'motan2://127.0.0.1:8001/com.mycompany.motan.DemoServer?group=bj&serialize=breeze';
$cx = new \Motan\Client();
$multi_res0=$cx->multiCall([
    new \Motan\URL($url_str),
    new \Motan\URL($url_str),
    new \Motan\URL($url_str),
],"Hello","client-multiple-call");
var_dump($multi_res0);
```
